### PR TITLE
Fixup for checking minLength of a string

### DIFF
--- a/src/DB/Entity/Validation/MetaImplementation.php
+++ b/src/DB/Entity/Validation/MetaImplementation.php
@@ -94,7 +94,7 @@ trait MetaImplementation
             $validation->addError("%s should no at most %s", $prop, $meta['max']);
         }
 
-        if (isset($meta['minLength']) && strlen($this->$prop) > $meta['minLength']) {
+        if (isset($meta['minLength']) && strlen($this->$prop) < $meta['minLength']) {
             $validation->addError("%s should be at least %d characters", $prop, $meta['minLength']);
         }
 


### PR DESCRIPTION
When validating minLength through meta, the wrong operator was used.